### PR TITLE
vmod-jq: fix vcs url in debian package

### DIFF
--- a/vmod-jq/debian/control
+++ b/vmod-jq/debian/control
@@ -13,7 +13,7 @@ Build-Depends:
  varnish (= @VERSION@),
  varnish-dev (= @VERSION@),
 Standards-Version: 3.9.5
-Vcs-Git: git://github.com/otto-de/libvmod-jq.git
+Vcs-Git: git://github.com/varnishcache-friends/libvmod-jq.git
 
 Package: vmod-jq
 Architecture: any


### PR DESCRIPTION
# Summary

update and fix the Vcs-Git parameter for vmod-jq so it points to the same URL as the rpm spec. Seems like a small copy & paste error as we are not aware of maintaining the package :)